### PR TITLE
Harden app for production: type safety, UX states, config and logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: make install
 
+      - name: Type check
+        run: make typecheck
+
       - name: Lint
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ test_debug:
 test_watch:
 	npm run test:watch
 
+.PHONY: typecheck
+typecheck:
+	npm run typecheck
+
 .PHONY: lint
 lint:
 	npm run lint
@@ -51,7 +55,7 @@ format_check:
 	npm run format:check
 
 .PHONY: before_commit
-before_commit: test format lint
+before_commit: typecheck test format lint
 
 .PHONY: run_frontend
 run_frontend:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ Copy `.env_sample` to `.env` and adjust as necessary:
 - `EXPO_PUBLIC_CIRCUIT_ID`: Your circuit ID for zero-knowledge proofs.
 - `LOCAL_IP_ADDR`: Your local IP address (for Expo in Docker+docker-compose setups).
 
+## Development
+
+The following quality checks run in CI and can be run locally from the
+repository root. They mirror the steps enforced on every pull request:
+
+```bash
+make typecheck    # TypeScript type checking (tsc --noEmit)
+make lint         # ESLint
+make format_check # Prettier formatting check
+make test         # Unit tests
+make test_coverage # Unit tests with coverage report
+```
+
+`make before_commit` runs the type check, tests, formatter, and linter
+together as a pre-commit gate.
+
 ## Future Prospects
 
 `Inro` aims

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "cd packages/frontend && npm run test",
     "test:coverage": "cd packages/frontend && npm run test:coverage",
     "test:watch": "cd packages/frontend && npm run test:watch",
+    "typecheck": "cd packages/frontend && npm run typecheck",
     "lint": "cd packages/frontend && npm run lint",
     "lint:fix": "cd packages/frontend && npm run lint:fix",
     "lint:text": "npx textlint ./README.md",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{ts,tsx}' --fix",
     "format": "prettier --write 'src/**/*.{ts,tsx,json,md}'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx,json,css}'",

--- a/packages/frontend/src/__mocks__/react-native-config.js
+++ b/packages/frontend/src/__mocks__/react-native-config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  EXPO_PUBLIC_SINDRI_API_KEY: 'your_api_key',
-  EXPO_PUBLIC_SINDRI_API_URL: 'https://sindri.app/api/',
-  EXPO_PUBLIC_API_VERSION: 'v1',
-  EXPO_PUBLIC_CIRCUIT_ID: 'e98c114f-6b0d-4fe0-9379-4ee91a1c6963',
-};

--- a/packages/frontend/src/__tests__/ageCalculator.test.ts
+++ b/packages/frontend/src/__tests__/ageCalculator.test.ts
@@ -1,6 +1,10 @@
 import { calculateAge } from '../utils/ageCalculator';
 
 describe('calculateAge', () => {
+  it('returns NaN for an unparseable date string', () => {
+    expect(Number.isNaN(calculateAge('not-a-date'))).toBe(true);
+  });
+
   it('should correctly calculate age from "YYYYMMDD" string', () => {
     const birthDateString = '19900101';
     const expectedAge = new Date().getFullYear() - 1990;

--- a/packages/frontend/src/__tests__/env.test.ts
+++ b/packages/frontend/src/__tests__/env.test.ts
@@ -1,0 +1,15 @@
+import { SINDRI_API_BASE_URL, env, isSindriConfigured } from '../config/env';
+
+describe('env config', () => {
+  it('derives the v1 base url from the api url', () => {
+    expect(SINDRI_API_BASE_URL).toBe(`${env.sindriApiUrl}v1`);
+  });
+
+  it('falls back to a default circuit id', () => {
+    expect(env.circuitId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('reports configuration state based on the api key', () => {
+    expect(isSindriConfigured()).toBe(env.sindriApiKey.length > 0);
+  });
+});

--- a/packages/frontend/src/__tests__/logger.test.ts
+++ b/packages/frontend/src/__tests__/logger.test.ts
@@ -1,0 +1,27 @@
+import { logger } from '../utils/logger';
+
+describe('logger', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('always emits warnings and errors', () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const error = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    logger.warn('a warning');
+    logger.error('an error');
+
+    expect(warn).toHaveBeenCalledWith('a warning');
+    expect(error).toHaveBeenCalledWith('an error');
+  });
+
+  it('exposes debug and info methods', () => {
+    expect(typeof logger.debug).toBe('function');
+    expect(typeof logger.info).toBe('function');
+  });
+});

--- a/packages/frontend/src/__tests__/sindriRepository.test.ts
+++ b/packages/frontend/src/__tests__/sindriRepository.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import Config from 'react-native-config';
+import { SINDRI_API_BASE_URL, env } from '../config/env';
 import SindriRepository from '../repository/SindriRepository';
 
 jest.mock('axios');
@@ -9,6 +9,7 @@ describe('SindriRepository', () => {
   let repo: SindriRepository;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     repo = new SindriRepository();
   });
 
@@ -17,11 +18,11 @@ describe('SindriRepository', () => {
     await repo.getRequest(endpoint);
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      `${Config.SINDRI_API_URL || 'https://sindri.app/api/'}v1${endpoint}`,
+      `${SINDRI_API_BASE_URL}${endpoint}`,
       {
         headers: {
           Accept: 'application/json',
-          Authorization: `Bearer ${Config.SINDRI_API_KEY || ''}`,
+          Authorization: `Bearer ${env.sindriApiKey}`,
         },
       }
     );
@@ -33,50 +34,14 @@ describe('SindriRepository', () => {
     await repo.postRequest(endpoint, data);
 
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      `${Config.SINDRI_API_URL || 'https://sindri.app/api/'}v1${endpoint}`,
+      `${SINDRI_API_BASE_URL}${endpoint}`,
       data,
       {
         headers: {
           Accept: 'application/json',
-          Authorization: `Bearer ${Config.SINDRI_API_KEY || ''}`,
+          Authorization: `Bearer ${env.sindriApiKey}`,
         },
       }
     );
-  });
-});
-
-describe('SindriRepository - pollForStatus', () => {
-  let repo: SindriRepository;
-  const endpoint = '/status';
-  const initialResponse = { data: { status: 'Processing' } };
-  const finalResponse = { data: { status: 'Ready' } };
-
-  beforeEach(() => {
-    repo = new SindriRepository();
-    jest.clearAllMocks();
-  });
-
-  it('should poll endpoint until status is "Ready"', async () => {
-    mockedAxios.get
-      .mockResolvedValueOnce(initialResponse)
-      .mockResolvedValueOnce(initialResponse)
-      .mockResolvedValueOnce(finalResponse);
-
-    const result = await repo.pollForStatus(endpoint, 3);
-    expect(result).toEqual(finalResponse);
-    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      expect.stringContaining(endpoint),
-      expect.objectContaining({ headers: expect.any(Object) })
-    );
-  });
-
-  it('should throw an error if polling times out', async () => {
-    mockedAxios.get.mockResolvedValue(initialResponse);
-
-    await expect(repo.pollForStatus(endpoint, 2)).rejects.toThrow(
-      'Polling timed out after 2 seconds.'
-    );
-    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/frontend/src/__tests__/sindriService.test.ts
+++ b/packages/frontend/src/__tests__/sindriService.test.ts
@@ -1,133 +1,144 @@
+import { AxiosResponse } from 'axios';
+import { env } from '../config/env';
 import SindriRepository from '../repository/SindriRepository';
 import SindriService from '../service/SindriService';
 
+const axiosResponse = <T>(data: T): AxiosResponse<T> =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  }) as AxiosResponse<T>;
+
 describe('SindriService', () => {
+  let repository: SindriRepository;
   let service: SindriService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new SindriService();
-
-    jest
-      .spyOn(SindriRepository.prototype, 'postRequest')
-      .mockImplementation((endpoint) => {
-        if (endpoint.includes('/prove')) {
-          return Promise.resolve({
-            data: { proof_id: '12345', perform_verify: 'true' },
-          });
-        }
-        return Promise.reject(new Error('Endpoint not mocked'));
-      });
-
-    jest
-      .spyOn(SindriRepository.prototype, 'getRequest')
-      .mockImplementation((endpoint) => {
-        if (endpoint.includes('/detail')) {
-          return Promise.resolve({
-            data: {
-              status: 'Ready',
-              proof: {
-                proof: 'fetched-proof-string',
-              },
-              public: {
-                'Verifier.toml': 'return = true\n',
-              },
-            },
-          });
-        }
-        return Promise.reject(new Error('Endpoint not mocked'));
-      });
-
-    jest
-      .spyOn(SindriRepository.prototype, 'pollForStatus')
-      .mockImplementation((endpoint) => {
-        if (endpoint.includes('/detail')) {
-          return Promise.resolve({
-            data: {
-              status: 'Ready',
-              proof: {
-                proof: 'fetched-proof-string',
-              },
-              public: {
-                'Verifier.toml': 'return = false\n',
-              },
-            },
-          });
-        }
-        return Promise.reject(new Error('Endpoint not mocked'));
-      });
+    repository = new SindriRepository();
+    service = new SindriService(repository);
   });
 
-  it('should generate proof successfully', async () => {
-    const input = 20;
-    await service.generateProof(input);
-    expect(SindriRepository.prototype.postRequest).toHaveBeenCalledWith(
-      `/circuit/6ea50e49-065a-4dc6-b7e6-b0e1ba3665f1/prove`,
-      { proof_input: `input = ${input}`, perform_verify: 'true' }
-    );
+  describe('generateProof', () => {
+    it('requests a proof for the given age and returns the proof id', async () => {
+      const post = jest
+        .spyOn(repository, 'postRequest')
+        .mockResolvedValue(axiosResponse({ proof_id: '12345' }));
+
+      const proofId = await service.generateProof(20);
+
+      expect(proofId).toBe('12345');
+      expect(post).toHaveBeenCalledWith(`/circuit/${env.circuitId}/prove`, {
+        proof_input: 'input = 20',
+        perform_verify: 'true',
+      });
+    });
+
+    it('throws when the API does not return a proof id', async () => {
+      jest
+        .spyOn(repository, 'postRequest')
+        .mockResolvedValue(axiosResponse({}));
+
+      await expect(service.generateProof(20)).rejects.toThrow(
+        'Failed to generate proof'
+      );
+    });
+
+    it('throws when the request fails', async () => {
+      jest
+        .spyOn(repository, 'postRequest')
+        .mockRejectedValue(new Error('network down'));
+
+      await expect(service.generateProof(20)).rejects.toThrow(
+        'Failed to generate proof'
+      );
+    });
   });
 
-  it('should handle polling for status correctly', async () => {
-    const endpoint = '/proof/12345/detail';
-    const response = await service.pollForStatus(endpoint, 10);
-    expect(response.data.status).toBe('Ready');
+  describe('pollForStatus', () => {
+    it('polls until a terminal status is reached', async () => {
+      const get = jest
+        .spyOn(repository, 'getRequest')
+        .mockResolvedValueOnce(axiosResponse({ status: 'In Progress' }))
+        .mockResolvedValueOnce(axiosResponse({ status: 'Ready' }));
+
+      const response = await service.pollForStatus('/proof/1/detail', 5);
+
+      expect(response.data.status).toBe('Ready');
+      expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws when polling times out', async () => {
+      jest
+        .spyOn(repository, 'getRequest')
+        .mockResolvedValue(axiosResponse({ status: 'In Progress' }));
+
+      await expect(service.pollForStatus('/proof/1/detail', 2)).rejects.toThrow(
+        'Polling timed out after 2 seconds.'
+      );
+    });
   });
 
-  it('returns true for a successful verification', async () => {
-    const proofId = '12345';
-    jest
-      .spyOn(SindriRepository.prototype, 'pollForStatus')
-      .mockResolvedValueOnce({
-        data: {
+  describe('fetchProofDetail', () => {
+    it('returns true when the proof is valid and meets the age requirement', async () => {
+      jest.spyOn(repository, 'getRequest').mockResolvedValue(
+        axiosResponse({
           status: 'Ready',
-          public: { 'Verifier.toml': 'return = true\n' },
           perform_verify: true,
-        },
-      });
+          public: { 'Verifier.toml': 'return = true\n' },
+        })
+      );
 
-    const isVerified = await service.fetchProofDetail(proofId);
-    expect(isVerified).toBe(true);
+      await expect(service.fetchProofDetail('12345')).resolves.toBe(true);
+    });
+
+    it('returns false when the age requirement is not met', async () => {
+      jest.spyOn(repository, 'getRequest').mockResolvedValue(
+        axiosResponse({
+          status: 'Ready',
+          perform_verify: true,
+          public: { 'Verifier.toml': 'return = false\n' },
+        })
+      );
+
+      await expect(service.fetchProofDetail('12345')).resolves.toBe(false);
+    });
+
+    it('returns false when the verification output is missing', async () => {
+      jest
+        .spyOn(repository, 'getRequest')
+        .mockResolvedValue(
+          axiosResponse({ status: 'Ready', perform_verify: true, public: {} })
+        );
+
+      await expect(service.fetchProofDetail('12345')).resolves.toBe(false);
+    });
+
+    it('throws when proving failed', async () => {
+      jest
+        .spyOn(repository, 'getRequest')
+        .mockResolvedValue(axiosResponse({ status: 'Failed' }));
+
+      await expect(service.fetchProofDetail('12345')).rejects.toThrow(
+        'Proving failed'
+      );
+    });
   });
 
-  it('returns false for a failed verification', async () => {
-    const proofId = '67890';
-    const isVerified = await service.fetchProofDetail(proofId);
-    expect(isVerified).toBe(false);
-  });
+  describe('verifyProof', () => {
+    it('returns the verification result', async () => {
+      jest.spyOn(service, 'fetchProofDetail').mockResolvedValue(true);
+      await expect(service.verifyProof('12345')).resolves.toBe(true);
+    });
 
-  it('throws an error if proof fetching fails', async () => {
-    const proofId = 'failed-proof-id';
-    jest
-      .spyOn(SindriRepository.prototype, 'pollForStatus')
-      .mockRejectedValueOnce(new Error('Proving failed'));
-
-    await expect(service.fetchProofDetail(proofId)).rejects.toThrow(
-      'Proving failed'
-    );
-  });
-
-  it('should verify proof successfully when verification result is true', async () => {
-    const proofId = '12345';
-    jest.spyOn(service, 'fetchProofDetail').mockResolvedValue(true);
-    const result = await service.verifyProof(proofId);
-    expect(service.fetchProofDetail).toHaveBeenCalledWith(proofId);
-    expect(result).toBe(true);
-  });
-
-  it('should not verify proof successfully when verification result is false', async () => {
-    const proofId = '67890';
-    jest.spyOn(service, 'fetchProofDetail').mockResolvedValue(false);
-    const result = await service.verifyProof(proofId);
-    expect(service.fetchProofDetail).toHaveBeenCalledWith(proofId);
-    expect(result).toBe(false);
-  });
-
-  it('should return false when proof fetching fails', async () => {
-    const proofId = 'failed-proof-id';
-    jest
-      .spyOn(service, 'fetchProofDetail')
-      .mockRejectedValue(new Error('Proving failed'));
-    const result = await service.verifyProof(proofId);
-    expect(result).toBe(false);
+    it('returns false when verification throws', async () => {
+      jest
+        .spyOn(service, 'fetchProofDetail')
+        .mockRejectedValue(new Error('Proving failed'));
+      await expect(service.verifyProof('12345')).resolves.toBe(false);
+    });
   });
 });

--- a/packages/frontend/src/components/ProveScreen.tsx
+++ b/packages/frontend/src/components/ProveScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import {
+  ActivityIndicator,
   Keyboard,
   Text,
   TextInput,
@@ -12,6 +13,8 @@ import { useGenerateProof } from '../hooks/useGenerateProof';
 import { styles } from '../styles/AppStyles';
 import { calculateAge } from '../utils/ageCalculator';
 
+const PIN_LENGTH = 4;
+
 const ProveScreen = (): JSX.Element => {
   const pinInputRefs = [
     useRef<TextInput>(null),
@@ -20,23 +23,47 @@ const ProveScreen = (): JSX.Element => {
     useRef<TextInput>(null),
   ];
 
-  const [pin, setPin] = useState(['', '', '', '']);
-  const { handleGenerateProof, proofResult } = useGenerateProof();
+  const [pin, setPin] = useState<string[]>(Array(PIN_LENGTH).fill(''));
+  const [isScanning, setIsScanning] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const { handleGenerateProof, proofResult, isGenerating, error, reset } =
+    useGenerateProof();
+
+  const isPinComplete = pin.every((digit) => digit !== '');
+  const isBusy = isScanning || isGenerating;
 
   const handleScan = async () => {
-    const result = await scan(pin.join(''));
-    const age = calculateAge(result);
-    handleGenerateProof(age);
+    if (!isPinComplete || isBusy) {
+      return;
+    }
+    Keyboard.dismiss();
+    setScanError(null);
+    reset();
+    setIsScanning(true);
+    try {
+      const birthDate = await scan(pin.join(''));
+      const age = calculateAge(birthDate);
+      if (Number.isNaN(age)) {
+        setScanError('Could not read a valid date of birth from the card.');
+        return;
+      }
+      await handleGenerateProof(age);
+    } catch {
+      setScanError('Failed to read the card. Please try again.');
+    } finally {
+      setIsScanning(false);
+    }
   };
 
   const handlePinChange = (text: string, index: number) => {
+    const digit = text.replace(/[^0-9]/g, '').slice(-1);
     const newPin = [...pin];
-    newPin[index] = text;
+    newPin[index] = digit;
     setPin(newPin);
 
-    if (text !== '' && index < 3) {
+    if (digit !== '' && index < PIN_LENGTH - 1) {
       pinInputRefs[index + 1].current?.focus();
-    } else if (text === '' && index > 0) {
+    } else if (digit === '' && index > 0) {
       pinInputRefs[index - 1].current?.focus();
     }
   };
@@ -45,7 +72,7 @@ const ProveScreen = (): JSX.Element => {
     <View style={styles.container} onTouchStart={() => Keyboard.dismiss()}>
       <Text>Enter the pin code</Text>
       <View style={styles.pinContainer}>
-        {Array.from({ length: 4 }).map((_, index) => (
+        {Array.from({ length: PIN_LENGTH }).map((_, index) => (
           <TextInput
             ref={pinInputRefs[index]}
             key={index}
@@ -55,13 +82,37 @@ const ProveScreen = (): JSX.Element => {
             maxLength={1}
             keyboardType="numeric"
             secureTextEntry={true}
+            editable={!isBusy}
           />
         ))}
       </View>
-      <TouchableOpacity onPress={handleScan} style={styles.button}>
+      <TouchableOpacity
+        onPress={handleScan}
+        style={[
+          styles.button,
+          (!isPinComplete || isBusy) && styles.buttonDisabled,
+        ]}
+        disabled={!isPinComplete || isBusy}
+      >
         <Text style={styles.buttonText}>Start Scan Your ID</Text>
       </TouchableOpacity>
-      {proofResult && proofResult !== '' && (
+
+      {isBusy && (
+        <View style={styles.statusContainer}>
+          <ActivityIndicator size="large" color="#007bff" />
+          <Text style={styles.statusText}>
+            {isScanning
+              ? 'Reading your card...'
+              : 'Generating proof. This can take a little while...'}
+          </Text>
+        </View>
+      )}
+
+      {(scanError || error) && !isBusy && (
+        <Text style={styles.errorText}>{scanError ?? error}</Text>
+      )}
+
+      {proofResult && proofResult !== '' && !isBusy && (
         <View style={styles.qrCodeContainer}>
           <Text>Show this QR code to the verifier</Text>
           <QRCode value={proofResult} size={200} />

--- a/packages/frontend/src/components/VerifyScreen.tsx
+++ b/packages/frontend/src/components/VerifyScreen.tsx
@@ -1,21 +1,26 @@
 import { Camera } from 'expo-camera';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect, useState } from 'react';
-import { Button, Text, View } from 'react-native';
+import { ActivityIndicator, Button, Text, View } from 'react-native';
 import { useVerifyAge } from '../hooks/useVerifyProof';
+import { logger } from '../utils/logger';
 import { styles } from '../styles/AppStyles';
 
 const VerifyScreen = (): JSX.Element => {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
-  const { verifyProof, verificationResult, verificationSuccess } =
+  const { verifyProof, verificationResult, verificationSuccess, isVerifying } =
     useVerifyAge();
 
   useEffect(() => {
     (async () => {
-      const { status } = await Camera.requestCameraPermissionsAsync();
-      setHasPermission(status === 'granted');
-      console.log('Camera permission status:', hasPermission);
+      try {
+        const { status } = await Camera.requestCameraPermissionsAsync();
+        setHasPermission(status === 'granted');
+      } catch (error) {
+        logger.error('Failed to request camera permission', error);
+        setHasPermission(false);
+      }
     })();
   }, []);
 
@@ -24,24 +29,63 @@ const VerifyScreen = (): JSX.Element => {
     await verifyProof(data);
   };
 
+  const handleScanAgain = () => {
+    setScanned(false);
+  };
+
+  if (hasPermission === null) {
+    return (
+      <View style={styles.container}>
+        <StatusBar style="auto" />
+        <ActivityIndicator size="large" color="#007bff" />
+        <Text style={styles.statusText}>Requesting camera permission...</Text>
+      </View>
+    );
+  }
+
+  if (hasPermission === false) {
+    return (
+      <View style={styles.container}>
+        <StatusBar style="auto" />
+        <Text style={styles.permissionText}>
+          Camera access is required to scan the verification QR code. Please
+          enable camera permission for Inro in your device settings.
+        </Text>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <StatusBar style="auto" />
       {scanned ? (
-        <Text
-          style={
-            verificationSuccess ? styles.successMessage : styles.failMessage
-          }
-        >
-          Verification Result: {verificationResult}
-        </Text>
+        <>
+          {isVerifying ? (
+            <View style={styles.statusContainer}>
+              <ActivityIndicator size="large" color="#007bff" />
+              <Text style={styles.statusText}>Verifying proof...</Text>
+            </View>
+          ) : (
+            <Text
+              style={
+                verificationSuccess ? styles.successMessage : styles.failMessage
+              }
+            >
+              Verification Result: {verificationResult}
+            </Text>
+          )}
+        </>
       ) : (
         <Camera
           onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
           style={styles.camera}
         />
       )}
-      <Button title={'Scan again'} onPress={() => setScanned(false)} />
+      <Button
+        title={'Scan again'}
+        onPress={handleScanAgain}
+        disabled={isVerifying}
+      />
     </View>
   );
 };

--- a/packages/frontend/src/config/env.ts
+++ b/packages/frontend/src/config/env.ts
@@ -1,0 +1,30 @@
+/**
+ * Centralized, typed access to the runtime configuration.
+ *
+ * All values originate from Expo's public environment variables
+ * (`EXPO_PUBLIC_*`), which Expo inlines at build time. Reading them through
+ * this module keeps the source of truth in one place and lets the rest of the
+ * codebase depend on plain, validated values instead of `process.env` lookups
+ * scattered across files.
+ */
+
+const DEFAULT_API_URL = 'https://sindri.app/api/';
+const DEFAULT_CIRCUIT_ID = '6ea50e49-065a-4dc6-b7e6-b0e1ba3665f1';
+
+export const env = {
+  sindriApiKey: process.env.EXPO_PUBLIC_SINDRI_API_KEY || '',
+  sindriApiUrl: process.env.EXPO_PUBLIC_SINDRI_API_URL || DEFAULT_API_URL,
+  circuitId: process.env.EXPO_PUBLIC_CIRCUIT_ID || DEFAULT_CIRCUIT_ID,
+} as const;
+
+/** Base URL for v1 of the Sindri REST API, e.g. `https://sindri.app/api/v1`. */
+export const SINDRI_API_BASE_URL = `${env.sindriApiUrl}v1`;
+
+/**
+ * Whether a Sindri API key has been provided. Proof generation and
+ * verification require an authenticated key; callers can use this to fail
+ * fast with a clear message instead of issuing an unauthenticated request.
+ */
+export function isSindriConfigured(): boolean {
+  return env.sindriApiKey.length > 0;
+}

--- a/packages/frontend/src/hooks/useGenerateProof.ts
+++ b/packages/frontend/src/hooks/useGenerateProof.ts
@@ -1,26 +1,40 @@
 import { useState } from 'react';
 import SindriService from '../service/SindriService';
+import { logger } from '../utils/logger';
 
 const service = new SindriService();
 
 export const useGenerateProof = () => {
-  const [age, setAge] = useState<number>(0);
-  const [proofResult, setProof] = useState<string | null>(null);
+  const [proofResult, setProofResult] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleGenerateProof = async (age) => {
+  const handleGenerateProof = async (age: number): Promise<void> => {
+    setIsGenerating(true);
+    setError(null);
+    setProofResult(null);
     try {
       const result = await service.generateProof(age);
-      setProof(result);
-    } catch (error) {
-      console.error(error);
-      setProof(null);
+      setProofResult(result);
+    } catch (err) {
+      logger.error('useGenerateProof failed', err);
+      setError('Could not generate the proof. Please try again.');
+      setProofResult(null);
+    } finally {
+      setIsGenerating(false);
     }
   };
 
+  const reset = (): void => {
+    setProofResult(null);
+    setError(null);
+  };
+
   return {
-    age,
-    setAge,
     proofResult,
+    isGenerating,
+    error,
     handleGenerateProof,
+    reset,
   };
 };

--- a/packages/frontend/src/hooks/useVerifyProof.ts
+++ b/packages/frontend/src/hooks/useVerifyProof.ts
@@ -1,33 +1,38 @@
 import { useState } from 'react';
 import { Alert } from 'react-native';
 import SindriService from '../service/SindriService';
+import { logger } from '../utils/logger';
+
+const service = new SindriService();
 
 export const useVerifyAge = () => {
-  const [isVerifier, setIsVerifier] = useState(false);
-  const [verificationSuccess, setVerificationSuccess] = useState(true);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [verificationSuccess, setVerificationSuccess] = useState(false);
   const [verificationResult, setVerificationResult] = useState<string>('');
 
-  const verifyProof = async (proofId: string) => {
-    const service = new SindriService();
+  const verifyProof = async (proofId: string): Promise<void> => {
+    setIsVerifying(true);
     try {
       const result = await service.verifyProof(proofId);
       if (result) {
-        setVerificationResult(`Adult verification was successful.`);
+        setVerificationResult('Adult verification was successful.');
         setVerificationSuccess(true);
       } else {
-        setVerificationResult(`Verification failed.`);
+        setVerificationResult('Verification failed.');
         setVerificationSuccess(false);
       }
     } catch (error) {
+      logger.error('useVerifyAge failed', error);
       Alert.alert('Error', 'An error occurred during verification.');
       setVerificationSuccess(false);
-      setVerificationResult(`Error occurred during verification.`);
+      setVerificationResult('Error occurred during verification.');
+    } finally {
+      setIsVerifying(false);
     }
   };
 
   return {
-    isVerifier,
-    setIsVerifier,
+    isVerifying,
     verifyProof,
     verificationResult,
     verificationSuccess,

--- a/packages/frontend/src/repository/SindriRepository.ts
+++ b/packages/frontend/src/repository/SindriRepository.ts
@@ -1,42 +1,28 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
+import { env, SINDRI_API_BASE_URL } from '../config/env';
 
+/**
+ * Thin HTTP layer over the Sindri REST API. It only knows how to issue
+ * authenticated requests; orchestration such as polling for a terminal status
+ * lives in {@link SindriService}.
+ */
 class SindriRepository {
-  private API_KEY: string = process.env.EXPO_PUBLIC_SINDRI_API_KEY || '';
-  private API_URL: string = `${process.env.EXPO_PUBLIC_SINDRI_API_URL || 'https://sindri.app/api/'}v1`;
-  private headersJson = {
+  private readonly baseUrl: string = SINDRI_API_BASE_URL;
+  private readonly headers = {
     Accept: 'application/json',
-    Authorization: `Bearer ${this.API_KEY}`,
+    Authorization: `Bearer ${env.sindriApiKey}`,
   };
 
-  async getRequest(endpoint: string) {
-    return axios.get(`${this.API_URL}${endpoint}`, {
-      headers: this.headersJson,
+  async getRequest(endpoint: string): Promise<AxiosResponse> {
+    return axios.get(`${this.baseUrl}${endpoint}`, {
+      headers: this.headers,
     });
   }
 
-  async postRequest(endpoint: string, data: any) {
-    return axios.post(`${this.API_URL}${endpoint}`, data, {
-      headers: this.headersJson,
+  async postRequest(endpoint: string, data: unknown): Promise<AxiosResponse> {
+    return axios.post(`${this.baseUrl}${endpoint}`, data, {
+      headers: this.headers,
     });
-  }
-
-  async pollForStatus(endpoint, timeout = 20 * 60) {
-    for (let i = 0; i < timeout; i++) {
-      const response = await axios.get(`${this.API_URL}${endpoint}`, {
-        headers: this.headersJson,
-        validateStatus: (status) => status === 200,
-      });
-
-      const status = response.data.status;
-      if (['Ready', 'Failed'].includes(status)) {
-        console.log(`Poll exited after ${i} seconds with status: ${status}`);
-        return response;
-      }
-
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-
-    throw new Error(`Polling timed out after ${timeout} seconds.`);
   }
 }
 

--- a/packages/frontend/src/service/SindriService.ts
+++ b/packages/frontend/src/service/SindriService.ts
@@ -1,27 +1,41 @@
+import { AxiosResponse } from 'axios';
+import { env } from '../config/env';
 import SindriRepository from '../repository/SindriRepository';
+import { logger } from '../utils/logger';
+
+/** Terminal states reported by the Sindri proving/verification pipeline. */
+const TERMINAL_STATUSES: readonly string[] = ['Ready', 'Failed'];
+
+interface ProofDetailData {
+  status?: string;
+  perform_verify?: boolean | string;
+  public?: Record<string, string>;
+}
 
 class SindriService {
   private static readonly POLL_TIMEOUT_SECONDS = 20 * 60;
   private static readonly POLL_INTERVAL_MS = 1000;
-  private static readonly DEFAULT_CIRCUIT_ID =
-    '6ea50e49-065a-4dc6-b7e6-b0e1ba3665f1';
-  private repository: SindriRepository;
-  private circuitId: string;
+  private readonly repository: SindriRepository;
+  private readonly circuitId: string;
 
-  constructor() {
-    this.repository = new SindriRepository();
-    this.circuitId =
-      process.env.EXPO_PUBLIC_CIRCUIT_ID || SindriService.DEFAULT_CIRCUIT_ID;
+  constructor(repository: SindriRepository = new SindriRepository()) {
+    this.repository = repository;
+    this.circuitId = env.circuitId;
   }
+
+  /**
+   * Repeatedly polls `endpoint` until the response reaches a terminal status
+   * (`Ready` or `Failed`) or the timeout elapses.
+   */
   async pollForStatus(
     endpoint: string,
     timeout: number = SindriService.POLL_TIMEOUT_SECONDS
-  ) {
+  ): Promise<AxiosResponse> {
     for (let i = 0; i < timeout; i++) {
       const response = await this.repository.getRequest(endpoint);
-      const status = response.data.status;
-      if (['Ready', 'Failed'].includes(status)) {
-        console.log(`Poll exited after ${i} seconds with status: ${status}`);
+      const status = response.data?.status;
+      if (typeof status === 'string' && TERMINAL_STATUSES.includes(status)) {
+        logger.debug(`Poll exited after ${i} seconds with status: ${status}`);
         return response;
       }
       await new Promise((resolve) =>
@@ -31,12 +45,16 @@ class SindriService {
     throw new Error(`Polling timed out after ${timeout} seconds.`);
   }
 
-  async generateProof(input: number) {
+  /**
+   * Requests a proof for the given age `input` and returns the proof id.
+   * The raw input is deliberately never logged: it is the user's age, which
+   * must not leak into diagnostics.
+   */
+  async generateProof(input: number): Promise<string> {
     try {
-      console.log(`Circuit ID: ${this.circuitId}`);
-      console.log('Proving circuit...');
-      console.log('Requesting proof from Sindri API...');
-      console.log(`Input: ${input}`);
+      logger.debug(
+        `Requesting proof from Sindri API (circuit ${this.circuitId})`
+      );
       const proofInput = {
         proof_input: `input = ${input}`,
         perform_verify: 'true',
@@ -47,38 +65,51 @@ class SindriService {
         endpoint,
         proofInput
       );
-      const proofId = proveResponse.data.proof_id;
-      console.log(`Proof ID: ${proofId}`);
+      const proofId = proveResponse.data?.proof_id;
+      if (!proofId) {
+        throw new Error('Sindri API did not return a proof id');
+      }
+      logger.debug(`Proof requested: ${proofId}`);
       return proofId;
     } catch (error) {
-      console.error(
-        error instanceof Error ? error.message : 'An unknown error occurred.'
+      logger.error(
+        'Failed to generate proof:',
+        error instanceof Error ? error.message : 'unknown error'
       );
       throw new Error('Failed to generate proof');
     }
   }
 
+  /**
+   * Fetches a proof's detail, waiting for it to finish proving, and returns
+   * whether it both proved successfully and satisfies the age predicate.
+   */
   async fetchProofDetail(proofId: string): Promise<boolean> {
-    console.log('Request the proof detail from Sindri API...');
+    logger.debug('Requesting proof detail from Sindri API...');
     const endpoint = `/proof/${proofId}/detail`;
-    const proofDetailResponse = await this.repository.pollForStatus(endpoint);
-    const proofDetailStatus = proofDetailResponse.data.status;
-    if (proofDetailStatus === 'Failed') {
+    const response = await this.pollForStatus(endpoint);
+    const data: ProofDetailData = response.data ?? {};
+
+    if (data.status === 'Failed') {
       throw new Error('Proving failed');
     }
-    const ageVerificationStatus =
-      proofDetailResponse.data.public['Verifier.toml'];
-    console.log(`Verification Result: ${ageVerificationStatus}`);
-    const isProofValid = proofDetailResponse.data.perform_verify;
-    console.log(`Is Verified: ${isProofValid}`);
-    return ageVerificationStatus.includes('true') && isProofValid;
+
+    const ageVerificationStatus = data.public?.['Verifier.toml'];
+    if (typeof ageVerificationStatus !== 'string') {
+      logger.warn('Proof detail is missing the verification output');
+      return false;
+    }
+
+    const meetsAgeRequirement = ageVerificationStatus.includes('true');
+    const proofWasVerified = Boolean(data.perform_verify);
+    return meetsAgeRequirement && proofWasVerified;
   }
 
   async verifyProof(proofId: string): Promise<boolean> {
     try {
       return await this.fetchProofDetail(proofId);
     } catch (error) {
-      console.error('Proof verification failed', error);
+      logger.error('Proof verification failed', error);
       return false;
     }
   }

--- a/packages/frontend/src/styles/AppStyles.ts
+++ b/packages/frontend/src/styles/AppStyles.ts
@@ -128,4 +128,29 @@ export const styles = StyleSheet.create({
     shadowRadius: 3,
     elevation: 2,
   },
+  buttonDisabled: {
+    backgroundColor: '#9bbfe0',
+  },
+  statusContainer: {
+    marginTop: 20,
+    alignItems: 'center',
+  },
+  statusText: {
+    fontSize: 14,
+    color: '#555',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  errorText: {
+    fontSize: 14,
+    color: '#D32F2F',
+    marginTop: 16,
+    textAlign: 'center',
+  },
+  permissionText: {
+    fontSize: 16,
+    color: '#555',
+    textAlign: 'center',
+    paddingHorizontal: 24,
+  },
 });

--- a/packages/frontend/src/utils/logger.ts
+++ b/packages/frontend/src/utils/logger.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal logging utility.
+ *
+ * In development every level is emitted to the console. In production only
+ * `warn` and `error` are emitted, which keeps release builds quiet and avoids
+ * leaking diagnostic detail. Callers must never pass privacy-sensitive data
+ * (ages, dates of birth, PINs, proof inputs) to the logger — for an identity
+ * verification app that data must stay off the logs entirely.
+ */
+
+type LogArgs = unknown[];
+
+function isDevEnvironment(): boolean {
+  // `__DEV__` is injected by React Native/Expo at build time. Under the Node
+  // based test runner it is undefined, so fall back to NODE_ENV.
+  if (typeof __DEV__ !== 'undefined') {
+    return __DEV__;
+  }
+  return process.env.NODE_ENV !== 'production';
+}
+
+const isDev = isDevEnvironment();
+
+export const logger = {
+  debug(...args: LogArgs): void {
+    if (isDev) {
+      console.debug(...args);
+    }
+  },
+  info(...args: LogArgs): void {
+    if (isDev) {
+      console.info(...args);
+    }
+  },
+  warn(...args: LogArgs): void {
+    console.warn(...args);
+  },
+  error(...args: LogArgs): void {
+    console.error(...args);
+  },
+};


### PR DESCRIPTION
## Overview

A focused production-hardening pass on the **Inro** age-verification app. The goal was to move the hackathon codebase toward commercial quality by closing concrete, *enforceable* gaps — every change below is covered by tests and/or a CI gate.

## What changed

### Enforced type safety (the big one)
- `tsc --noEmit` previously **failed with 6 type errors**, but CI never ran the typechecker so the debt was invisible.
- Added a `typecheck` npm script + `make typecheck` target, wired it into the CI workflow and `before_commit`, and fixed all 6 errors.

### Configuration
- New `src/config/env.ts` is the single source of truth for the Sindri API key / URL / circuit id, replacing scattered `process.env` reads.
- Removed the unused `react-native-config` wiring (it was only referenced in a test, while the source used `process.env` — the two never matched).
- Added `isSindriConfigured()` so callers can fail fast when no API key is present.

### Logging hygiene
- New `src/utils/logger.ts` quiets `debug`/`info` in production and **never logs the user's age / proof input** — important for an identity app.
- Replaced ad-hoc `console.*` calls across the service, hooks, and screens.

### Architecture / correctness
- Consolidated the **duplicated polling logic** (it existed in both the repository and the service, with divergent behavior) into `SindriService`; `SindriRepository` is now a thin, typed HTTP layer.
- Hardened proof-detail parsing against missing fields instead of assuming the shape.

### UX (real for commercial use)
- **Prove screen**: PIN validation, digit-only input, loading indicator during the (potentially long) proof generation, NFC/scan error messages, disabled button while busy.
- **Verify screen**: explicit camera-permission-denied state, a "verifying…" indicator, and removed a stale `console.log`.

### Tests
- Updated and expanded the suite (config, logger, service, repository, an age edge case). **21 tests passing.** Core modules (config, repository, service) at ~100% statement coverage.

## Verification
Ran the full CI sequence locally — all green:
`make typecheck` · `make lint` · `make format_check` · `make lint_text` · `make test_coverage`

## Out of scope (genuine commercial readiness still needs)
This is a hardening increment, not a release sign-off. Still recommended before shipping: a security audit of the ZK/identity flow, real-device QA (NFC + camera), dependency vulnerability remediation (Dependabot flags many), App Store/Play compliance review, and component/integration tests via a React Native testing library.

https://claude.ai/code/session_01F8dQuchCbCyWH4yUrCnJWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dQuchCbCyWH4yUrCnJWr)_